### PR TITLE
Fixed the casing of the (city)Id parameter, it should be lower case

### DIFF
--- a/OpenWeatherMap.Standard/Forecast.cs
+++ b/OpenWeatherMap.Standard/Forecast.cs
@@ -43,7 +43,7 @@ namespace OpenWeatherMap.Standard
 
         private string GetWeatherDataByCityIdUrl(string appId, int cityId, WeatherUnits units)
         {
-            return $"http://api.openweathermap.org/data/2.5/weather?Id={cityId}&appid={appId}&units={units.ToString()}";
+            return $"http://api.openweathermap.org/data/2.5/weather?id={cityId}&appid={appId}&units={units.ToString()}";
         }
 
         public async Task<WeatherData> GetWeatherDataByZipAsync(string appId, string zipCode, string countryCode = "us", WeatherUnits units = WeatherUnits.Standard)


### PR DESCRIPTION
Current implementation with parameter 'Id' gives back 400 - Nothing to Geocode.
According to the documentation querystring parameter 'id' is in lower case
eg api.openweathermap.org/data/2.5/weather?id=2172797


Signed-off-by: niko tanghe <ntanghe@gmail.com>