### PR TITLE
New models for Rain and Snow and Sea/Ground Atmospheric level properties

### DIFF
--- a/OpenWeatherMap.Standard/Models/Rain.cs
+++ b/OpenWeatherMap.Standard/Models/Rain.cs
@@ -1,0 +1,35 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace OpenWeatherMap.Standard.Models
+{
+    /// <summary>
+    /// rain model
+    /// </summary>
+    public class Rain : BaseModel
+    {
+        private float lastHour, lastThreeHours;
+
+        /// <summary>
+        /// last hour, mm
+        /// </summary>
+        [JsonProperty("1h")]
+        public float LastHour
+        {
+            get => lastHour;
+            set => SetProperty(ref lastHour, value);
+        }
+
+        /// <summary>
+        /// last three hours, mm
+        /// </summary>
+        [JsonProperty("3h")]
+        public float LastThreeHours
+        {
+            get => lastThreeHours;
+            set => SetProperty(ref lastThreeHours, value);
+        } 
+    }
+}

--- a/OpenWeatherMap.Standard/Models/Snow.cs
+++ b/OpenWeatherMap.Standard/Models/Snow.cs
@@ -1,0 +1,35 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace OpenWeatherMap.Standard.Models
+{
+    /// <summary>
+    /// snow model
+    /// </summary>
+    public class Snow : BaseModel
+    {
+        private float lastHour, lastThreeHours;
+
+        /// <summary>
+        /// last hour, mm
+        /// </summary>
+        [JsonProperty("1h")]
+        public float LastHour
+        {
+            get => lastHour;
+            set => SetProperty(ref lastHour, value);
+        }
+
+        /// <summary>
+        /// last three hours, mm
+        /// </summary>
+        [JsonProperty("3h")]
+        public float LastThreeHours
+        {
+            get => lastThreeHours;
+            set => SetProperty(ref lastThreeHours, value);
+        } 
+    }
+}

--- a/OpenWeatherMap.Standard/Models/WeatherData.cs
+++ b/OpenWeatherMap.Standard/Models/WeatherData.cs
@@ -19,6 +19,8 @@ namespace OpenWeatherMap.Standard.Models
         private WeatherDayInfo weatherDayInfo;
         private Wind wind;
         private Clouds clouds;
+        private Rain rain;
+        private Snow snow;
         private DateTime dt;
         private DayInfo dayInfo;
 
@@ -88,6 +90,24 @@ namespace OpenWeatherMap.Standard.Models
         {
             get => clouds;
             set => SetProperty(ref clouds, value);
+        }
+
+        /// <summary>
+        /// rain info
+        /// </summary>
+        public Rain Rain
+        {
+            get => rain;
+            set => SetProperty(ref rain, value);
+        }
+
+        /// <summary>
+        /// snow info
+        /// </summary>
+        public Snow Snow
+        {
+            get => snow;
+            set => SetProperty(ref snow, value);
         }
 
         /// <summary>

--- a/OpenWeatherMap.Standard/Models/WeatherDayInfo.cs
+++ b/OpenWeatherMap.Standard/Models/WeatherDayInfo.cs
@@ -8,7 +8,7 @@ namespace OpenWeatherMap.Standard.Models
     /// </summary>
     public class WeatherDayInfo : BaseModel
     {
-        private float temp, maxTemp, minTemp, pressure;
+        private float temp, maxTemp, minTemp, pressure, seaLevel, grndLevel;
         private int humidity;
 
         /// <summary>
@@ -57,6 +57,26 @@ namespace OpenWeatherMap.Standard.Models
         {
             get => maxTemp;
             set => SetProperty(ref maxTemp, value);
+        }
+
+        /// <summary>
+        /// Atmospheric pressure on the sea level, hPa
+        /// </summary>
+        [JsonProperty("sea_level")]
+        public float SeaLevel
+        {
+            get => seaLevel;
+            set => SetProperty(ref seaLevel, value);
+        }
+
+        /// <summary>
+        /// Atmospheric pressure on the ground level, hPa
+        /// </summary>
+        [JsonProperty("grnd_level")]
+        public float GroundLevel
+        {
+            get => grndLevel;
+            set => SetProperty(ref grndLevel, value);
         }
     }
 


### PR DESCRIPTION
This PR adds the following new properties to the Main object (**WeatherData**)

- `main.sea_level` Atmospheric pressure on the sea level, hPa
- `main.grnd_level` Atmospheric pressure on the ground level, hPa

Also, it add the _getter and setter_ for `Rain` and `Snow`