### PR TITLE
Add multilingual support

### DIFF
--- a/OpenWeatherMap.Standard/Attributes/LangValue.cs
+++ b/OpenWeatherMap.Standard/Attributes/LangValue.cs
@@ -1,0 +1,12 @@
+﻿namespace System
+{
+    public class LangValue : Attribute
+    {
+        public string Value { get; private set; }
+
+        public LangValue(string value)
+        {
+            Value = value;
+        }
+    }
+}

--- a/OpenWeatherMap.Standard/Current.cs
+++ b/OpenWeatherMap.Standard/Current.cs
@@ -58,6 +58,13 @@ namespace OpenWeatherMap.Standard
         public WeatherUnits Units { get; set; } = WeatherUnits.Metric;
 
         /// <summary>
+        /// Translation is only applied for the "description" field.
+        /// <para />
+        /// its default is English
+        /// </summary>
+        public Languages Languages { get; set; } = Languages.English;
+
+        /// <summary>
         /// indicate weather to call the API through HTTPS or not.
         /// <para />
         /// it's highly recommended to leave it true
@@ -104,18 +111,20 @@ namespace OpenWeatherMap.Standard
         }
 
         /// <summary>
-        /// a constructor that allows you to use your own IRestService implementation and set default measurements system
+        /// a constructor that allows you to use your own IRestService implementation and set default measurements system and language
         /// </summary>
         /// <param name="_appId">OWM app id</param>
         /// <param name="rest">your IRestService implementation</param>
         /// <param name="_units">desired system</param>
-        public Current(string _appId, IRestService rest, WeatherUnits _units)
+        /// <param name="_languages">desired language</param>
+        public Current(string _appId, IRestService rest, WeatherUnits _units, Languages _languages)
         {
             if (string.IsNullOrEmpty(_appId))
                 throw new ArgumentNullException("_appId", "AppId must NOT be null or empty string");
             AppId = _appId;
             Service = rest;
             Units = _units;
+            Languages = _languages;
         }
 
         /// <summary>
@@ -127,7 +136,7 @@ namespace OpenWeatherMap.Standard
         {
             if (string.IsNullOrEmpty(query))
                 throw new ArgumentNullException("query", "query can NOT be null or empty string");
-            return $"http{(UseHTTPS ? "s" : "")}://{API_ROOT}{API_VERSION}{WEATHER_REQUESTS_ROOT}?{query}&units={Units.ToString()}&appid={AppId}";
+            return $"http{(UseHTTPS ? "s" : "")}://{API_ROOT}{API_VERSION}{WEATHER_REQUESTS_ROOT}?{query}&units={Units.ToString()}&appid={AppId}&lang={Languages.GetStringValue()}";
         }
 
         /// <summary>

--- a/OpenWeatherMap.Standard/Enums/Languages.cs
+++ b/OpenWeatherMap.Standard/Enums/Languages.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace OpenWeatherMap.Standard.Enums
+{
+    /// <summary>
+    /// available languages enum
+    /// </summary>
+    public enum Languages
+    {
+        [LangValue("ar")]
+        Arabic,
+
+        [LangValue("bg")]
+        Bulgarian,
+
+        [LangValue("ca")]
+        Catalan,
+
+        [LangValue("cz")]
+        Czech,
+
+        [LangValue("de")]
+        German,
+
+        [LangValue("el")]
+        Greek,
+
+        [LangValue("en")]
+        English,
+
+        [LangValue("fa")]
+        PersianFarsi,
+
+        [LangValue("fi")]
+        Finnish,
+
+        [LangValue("fr")]
+        French,
+
+        [LangValue("gl")]
+        Galician,
+
+        [LangValue("hr")]
+        Croatian,
+
+        [LangValue("hu")]
+        Hungarian,
+
+        [LangValue("it")]
+        Italian,
+
+        [LangValue("ja")]
+        Japanese,
+
+        [LangValue("kr")]
+        Korean,
+
+        [LangValue("la")]
+        Latvian,
+
+        [LangValue("lt")]
+        Lithuanian,
+
+        [LangValue("mk")]
+        Macedonian,
+
+        [LangValue("nl")]
+        Dutch,
+
+        [LangValue("pl")]
+        Polish,
+
+        [LangValue("pt")]
+        Portuguese,
+
+        [LangValue("ro")]
+        Romanian,
+
+        [LangValue("ru")]
+        Russian,
+
+        [LangValue("se")]
+        Swedish,
+
+        [LangValue("sk")]
+        Slovak,
+
+        [LangValue("sl")]
+        Slovenian,
+
+        [LangValue("es")]
+        Spanish,
+
+        [LangValue("tr")]
+        Turkish,
+
+        [LangValue("ua")]
+        Ukrainian,
+
+        [LangValue("vi")]
+        Vietnamese,
+
+        [LangValue("zh_cn")]
+        ChineseSimplified,
+
+        [LangValue("zh_tw")]
+        ChineseTraditional
+    }
+}

--- a/OpenWeatherMap.Standard/Extensions/LangValueExtension.cs
+++ b/OpenWeatherMap.Standard/Extensions/LangValueExtension.cs
@@ -1,0 +1,23 @@
+﻿using System.Reflection;
+
+namespace System
+{
+    public static class LangValueExtension
+    {
+        public static string GetStringValue(this Enum value)
+        {
+            string stringValue = value.ToString();
+            Type type = value.GetType();
+            FieldInfo fieldInfo = type.GetField(value.ToString());
+            LangValue[] attrs = fieldInfo.
+                GetCustomAttributes(typeof(LangValue), false) as LangValue[];
+
+            if (attrs.Length > 0)
+            {
+                stringValue = attrs[0].Value;
+            }
+
+            return stringValue;
+        }
+    }
+}


### PR DESCRIPTION
Adds a new query parameter to change the language of response. English is the default language.

According to the official docs:

```
You can use lang parameter to get the output in your language. 
We support the following languages that you can use with the corresponded lang values:

Arabic - ar, 
Bulgarian - bg,
Catalan - ca, 
Czech - cz, 
German - de, 
Greek - el, 
English - en, 
Persian (Farsi) - fa, 
Finnish - fi, 
French - fr, 
Galician - gl, 
Croatian - hr, 
Hungarian - hu, 
Italian - it, 
Japanese - ja, 
Korean - kr, 
Latvian - la,
Lithuanian - lt, 
Macedonian - mk, 
Dutch - nl, 
Polish - pl, 
Portuguese - pt, 
Romanian - ro, 
Russian - ru, 
Swedish - se, 
Slovak - sk,
Slovenian - sl, 
Spanish - es, 
Turkish - tr, 
Ukrainian - ua, 
Vietnamese - vi, 
Chinese Simplified - zh_cn, 
Chinese Traditional - zh_tw.

**NOTE: Translation is only applied for the "description" field.**
```